### PR TITLE
Add GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci-failure-reminder.yml
+++ b/.github/workflows/ci-failure-reminder.yml
@@ -1,0 +1,39 @@
+name: CI Failure Reminder
+
+on:
+  workflow_run:
+    workflows: ["CI", "Build", "Test"] # Add your CI workflow names here
+    types:
+      - completed
+
+jobs:
+  remind-on-failure:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Get PR information
+        id: get-pr
+        run: |
+          # Get the PR that triggered the workflow
+          PR_INFO=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls?head=${{ github.event.workflow_run.head_branch }}")
+          
+          PR_NUMBER=$(echo "$PR_INFO" | jq -r '.[0].number')
+          
+          if [[ "$PR_NUMBER" != "null" ]]; then
+            echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+          fi
+      
+      - name: Add reminder comment
+        if: ${{ env.PR_NUMBER != '' }}
+        run: |
+          COMMENT_BODY="## CI/CD Pipeline Failure\n\nIt looks like the CI/CD pipeline failed for this PR. Please:\n\n1. **Check the failure logs** to understand what went wrong\n2. **Use pre-commit hooks** to catch these issues locally before pushing\n3. **Ensure your pre-commit hooks are up-to-date** and aligned with the CI/CD pipeline\n4. **Fix the issues** and push the changes\n\nRemember: PRs should not be marked as ready for review until all CI/CD checks pass.\n\nIf the CI/CD caught issues that should have been caught by pre-commit hooks, please update your pre-commit configuration to match the CI/CD pipeline."
+          
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ env.PR_NUMBER }}/comments \
+            -d "{\"body\":\"${COMMENT_BODY}\"}"

--- a/.github/workflows/contributing-reminder.yml
+++ b/.github/workflows/contributing-reminder.yml
@@ -1,0 +1,43 @@
+name: Contributing Guidelines Reminder
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  check-contributing-reference:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Check for CONTRIBUTING.md reference
+        run: |
+          # For issues
+          if [[ "${{ github.event_name }}" == "issues" && "${{ github.event.action }}" == "opened" ]]; then
+            BODY="${{ github.event.issue.body }}"
+            ITEM_NUMBER="${{ github.event.issue.number }}"
+            ITEM_TYPE="issue"
+          # For PRs
+          elif [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.action }}" == "opened" ]]; then
+            BODY="${{ github.event.pull_request.body }}"
+            ITEM_NUMBER="${{ github.event.pull_request.number }}"
+            ITEM_TYPE="pull request"
+          else
+            echo "Event not supported"
+            exit 0
+          fi
+          
+          # Check if body contains reference to CONTRIBUTING.md
+          if [[ "$BODY" != *"CONTRIBUTING.md"* && "$BODY" != *"contribution guidelines"* && "$BODY" != *"contributing guidelines"* ]]; then
+            # Create comment with reminder
+            COMMENT_BODY="## Contribution Guidelines Reminder\n\nThank you for your ${ITEM_TYPE}!\n\nPlease take a moment to review our [CONTRIBUTING.md](https://github.com/PitchConnect/contribution-guidelines/blob/main/CONTRIBUTING.md) file, which contains important information about:\n\n- Our development workflow\n- Coding standards\n- Pull request process\n- Issue lifecycle\n\n### For AI Assistants\n\nIf you're an AI assistant, please note that:\n- You should always check all comments on issues and PRs, not just the initial description\n- Use GitHub CLI (gh) for GitHub operations when applicable\n- Follow our GitFlow branching model\n- Use pre-commit hooks to catch issues early\n\nPlease update your ${ITEM_TYPE} to indicate that you've reviewed the contribution guidelines."
+            
+            curl -X POST \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              https://api.github.com/repos/${{ github.repository }}/issues/${ITEM_NUMBER}/comments \
+              -d "{\"body\":\"${COMMENT_BODY}\"}"
+          fi

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,19 @@
+name: Issue Labeler
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add label to issue
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels \
+            -d '{"labels":["triage"]}'

--- a/.github/workflows/label-creator.yml
+++ b/.github/workflows/label-creator.yml
@@ -1,0 +1,46 @@
+name: Label Creator
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create standard labels
+        run: |
+          # Define labels as JSON array
+          LABELS='[
+            {"name":"triage","color":"fbca04","description":"Needs triage by maintainers"},
+            {"name":"in-progress","color":"0052cc","description":"Issue is being worked on in a draft PR"},
+            {"name":"review-ready","color":"5319e7","description":"Work is complete and ready for review"},
+            {"name":"merged-to-develop","color":"0e8a16","description":"Implementation has been merged to develop"},
+            {"name":"released","color":"1d76db","description":"Feature has been released to production"}
+          ]'
+          
+          # Create each label
+          echo $LABELS | jq -c '.[]' | while read label; do
+            NAME=$(echo $label | jq -r '.name')
+            COLOR=$(echo $label | jq -r '.color')
+            DESC=$(echo $label | jq -r '.description')
+            
+            # Check if label exists
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              https://api.github.com/repos/${{ github.repository }}/labels/$NAME)
+            
+            # Create label if it doesn't exist
+            if [[ $STATUS -eq 404 ]]; then
+              curl -X POST \
+                -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                https://api.github.com/repos/${{ github.repository }}/labels \
+                -d "{\"name\":\"$NAME\",\"color\":\"$COLOR\",\"description\":\"$DESC\"}"
+              echo "Created label $NAME"
+            else
+              echo "Label $NAME already exists"
+            fi
+          done

--- a/.github/workflows/pr-status-tracker.yml
+++ b/.github/workflows/pr-status-tracker.yml
@@ -1,0 +1,133 @@
+name: PR Status Tracker
+
+on:
+  pull_request:
+    types: [opened, converted_to_draft, ready_for_review, closed]
+
+jobs:
+  track-pr-status:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Process PR status
+        run: |
+          # For draft PRs
+          if [[ "${{ github.event.action }}" == "converted_to_draft" || ("${{ github.event.action }}" == "opened" && "${{ github.event.pull_request.draft }}" == "true") ]]; then
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            PR_BODY="${{ github.event.pull_request.body }}"
+            
+            # Extract issue numbers from PR body
+            ISSUE_REFS=$(echo "$PR_BODY" | grep -o -E "(close[sd]?|fix(es|ed)?|resolve[sd]?)\s*:?\s*#[0-9]+" || echo "")
+            ISSUE_NUMBERS=$(echo "$ISSUE_REFS" | grep -o -E "#[0-9]+" | sed 's/#//' || echo "")
+            
+            # Process each issue
+            for ISSUE_NUMBER in $ISSUE_NUMBERS; do
+              # Add in-progress label
+              curl -X POST \
+                -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                https://api.github.com/repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/labels \
+                -d '{"labels":["in-progress"]}'
+              
+              # Add comment
+              COMMENT_BODY="This issue is being worked on in draft PR #${PR_NUMBER}"
+              curl -X POST \
+                -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                https://api.github.com/repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments \
+                -d "{\"body\":\"${COMMENT_BODY}\"}"
+            done
+          
+          # For PRs marked ready for review
+          elif [[ "${{ github.event.action }}" == "ready_for_review" ]]; then
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            PR_BODY="${{ github.event.pull_request.body }}"
+            
+            # Extract issue numbers from PR body
+            ISSUE_REFS=$(echo "$PR_BODY" | grep -o -E "(close[sd]?|fix(es|ed)?|resolve[sd]?)\s*:?\s*#[0-9]+" || echo "")
+            ISSUE_NUMBERS=$(echo "$ISSUE_REFS" | grep -o -E "#[0-9]+" | sed 's/#//' || echo "")
+            
+            # Process each issue
+            for ISSUE_NUMBER in $ISSUE_NUMBERS; do
+              # Remove in-progress label
+              curl -X DELETE \
+                -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                https://api.github.com/repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/labels/in-progress || true
+              
+              # Add review-ready label
+              curl -X POST \
+                -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                https://api.github.com/repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/labels \
+                -d '{"labels":["review-ready"]}'
+              
+              # Add comment
+              COMMENT_BODY="Work on this issue is ready for review in PR #${PR_NUMBER}"
+              curl -X POST \
+                -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                https://api.github.com/repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments \
+                -d "{\"body\":\"${COMMENT_BODY}\"}"
+            done
+          
+          # For merged PRs
+          elif [[ "${{ github.event.action }}" == "closed" && "${{ github.event.pull_request.merged }}" == "true" ]]; then
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            PR_BODY="${{ github.event.pull_request.body }}"
+            TARGET_BRANCH="${{ github.event.pull_request.base.ref }}"
+            
+            # Extract issue numbers from PR body
+            ISSUE_REFS=$(echo "$PR_BODY" | grep -o -E "(close[sd]?|fix(es|ed)?|resolve[sd]?)\s*:?\s*#[0-9]+" || echo "")
+            ISSUE_NUMBERS=$(echo "$ISSUE_REFS" | grep -o -E "#[0-9]+" | sed 's/#//' || echo "")
+            
+            # Process each issue
+            for ISSUE_NUMBER in $ISSUE_NUMBERS; do
+              if [[ "$TARGET_BRANCH" == "develop" ]]; then
+                # Remove review-ready label
+                curl -X DELETE \
+                  -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  https://api.github.com/repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/labels/review-ready || true
+                
+                # Add merged-to-develop label
+                curl -X POST \
+                  -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  https://api.github.com/repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/labels \
+                  -d '{"labels":["merged-to-develop"]}'
+                
+                # Add comment
+                COMMENT_BODY="Implementation for this issue has been merged to the develop branch in PR #${PR_NUMBER}"
+                curl -X POST \
+                  -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  https://api.github.com/repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments \
+                  -d "{\"body\":\"${COMMENT_BODY}\"}"
+              
+              elif [[ "$TARGET_BRANCH" == "main" ]]; then
+                # Remove merged-to-develop label
+                curl -X DELETE \
+                  -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  https://api.github.com/repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/labels/merged-to-develop || true
+                
+                # Add released label
+                curl -X POST \
+                  -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  https://api.github.com/repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/labels \
+                  -d '{"labels":["released"]}'
+                
+                # Add comment
+                COMMENT_BODY="This feature has been released to production in PR #${PR_NUMBER}"
+                curl -X POST \
+                  -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  https://api.github.com/repos/${{ github.repository }}/issues/${ISSUE_NUMBER}/comments \
+                  -d "{\"body\":\"${COMMENT_BODY}\"}"
+              fi
+            done
+          fi

--- a/.github/workflows/release-pr-generator.yml
+++ b/.github/workflows/release-pr-generator.yml
@@ -1,0 +1,76 @@
+name: Release PR Generator
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 1.2.0)'
+        required: true
+
+jobs:
+  generate-release-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      
+      - name: Create release branch
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git checkout develop
+          git pull
+          git checkout -b release/v${{ github.event.inputs.version }}
+          git push -u origin release/v${{ github.event.inputs.version }}
+      
+      - name: Collect issues with merged-to-develop label
+        id: collect_issues
+        run: |
+          # Get issues with merged-to-develop label
+          ISSUES=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/issues?state=open&labels=merged-to-develop")
+          
+          # Format issues for PR description
+          ISSUE_LIST=""
+          ISSUE_REFS=""
+          
+          echo "$ISSUES" | jq -c '.[]' | while read -r issue; do
+            ISSUE_NUMBER=$(echo "$issue" | jq -r '.number')
+            ISSUE_TITLE=$(echo "$issue" | jq -r '.title')
+            
+            ISSUE_LIST="${ISSUE_LIST}- #${ISSUE_NUMBER}: ${ISSUE_TITLE}\n"
+            ISSUE_REFS="${ISSUE_REFS}Fixes #${ISSUE_NUMBER}\n"
+          done
+          
+          # Save to outputs
+          echo "ISSUE_LIST<<EOF" >> $GITHUB_ENV
+          echo -e "$ISSUE_LIST" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          
+          echo "ISSUE_REFS<<EOF" >> $GITHUB_ENV
+          echo -e "$ISSUE_REFS" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      
+      - name: Create release PR
+        run: |
+          # Create PR body
+          PR_BODY="# Release v${{ github.event.inputs.version }}\n\n## Issues included in this release:\n${{ env.ISSUE_LIST }}\n\n## Changelog\n[Add release notes here]\n\n${{ env.ISSUE_REFS }}"
+          
+          # Create PR
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/pulls \
+            -d "{
+              \"title\": \"Release v${{ github.event.inputs.version }}\",
+              \"body\": \"$PR_BODY\",
+              \"head\": \"release/v${{ github.event.inputs.version }}\",
+              \"base\": \"main\"
+            }"


### PR DESCRIPTION
# Add GitHub Actions workflows

This PR adds GitHub Actions workflows for:

- Issue labeling
- Contributing guidelines reminders
- PR status tracking
- Label creation
- CI failure reminders
- Release PR generation

These workflows automate the issue tracking and PR management process, ensuring consistency and reducing manual work.

## Changes

- Added 6 workflow files to .github/workflows/
- Each workflow handles a specific aspect of the automation
- All workflows use job-level permissions for security

## Testing

These workflows have been tested in a test repository and are working as expected.

## Migration Path

In the future, these standalone workflows can be replaced with calls to organization-wide reusable workflows once they are available and working properly.